### PR TITLE
78209427 - Configure CUR S3 source bucket

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,20 @@
+config {
+  force = true
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+rule "terraform_module_pinned_source" {
+  enabled = false
+}
+
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+rule "terraform_required_providers" {
+  enabled = false
+}

--- a/s3-cur-source/cur.tf
+++ b/s3-cur-source/cur.tf
@@ -1,0 +1,20 @@
+resource "aws_cur_report_definition" "source" {
+  provider = aws.us_east_1
+
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_policy.source
+  ]
+
+  report_name                = "${var.resource_prefix}-${var.cur_name_suffix}"
+  time_unit                  = "HOURLY"
+  format                     = "Parquet"
+  compression                = "Parquet"
+  additional_schema_elements = var.enable_split_cost_allocation_data ? ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"] : ["RESOURCES"]
+  s3_bucket                  = aws_s3_bucket.source.bucket
+  s3_region                  = local.aws_region
+  s3_prefix                  = "cur/${local.account_id}"
+  additional_artifacts       = ["ATHENA"]
+  report_versioning          = "OVERWRITE_REPORT"
+  refresh_closed_reports     = true
+}

--- a/s3-cur-source/cur.tf
+++ b/s3-cur-source/cur.tf
@@ -6,15 +6,21 @@ resource "aws_cur_report_definition" "source" {
     aws_s3_bucket_policy.source
   ]
 
-  report_name                = "${var.resource_prefix}-${var.cur_name_suffix}"
-  time_unit                  = "HOURLY"
-  format                     = "Parquet"
-  compression                = "Parquet"
+  additional_artifacts       = ["ATHENA"]
   additional_schema_elements = var.enable_split_cost_allocation_data ? ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"] : ["RESOURCES"]
+  compression                = "Parquet"
+  format                     = "Parquet"
+  refresh_closed_reports     = true
+  report_name                = "${var.resource_prefix}-${var.cur_name_suffix}"
+  report_versioning          = "OVERWRITE_REPORT"
+  s3_prefix                  = "cur/${local.account_id}"
   s3_bucket                  = aws_s3_bucket.source.bucket
   s3_region                  = local.aws_region
-  s3_prefix                  = "cur/${local.account_id}"
-  additional_artifacts       = ["ATHENA"]
-  report_versioning          = "OVERWRITE_REPORT"
-  refresh_closed_reports     = true
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.resource_prefix}-${var.cur_name_suffix}"
+    }
+  )
+  time_unit = "HOURLY"
 }

--- a/s3-cur-source/data.tf
+++ b/s3-cur-source/data.tf
@@ -1,0 +1,121 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  policy_id = "CrossAccessPolicy"
+
+  statement {
+    sid     = "AllowTLS12Only"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.source.arn,
+      "${aws_s3_bucket.source.arn}/*",
+    ]
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = [1.2]
+    }
+  }
+
+  statement {
+    sid     = "AllowOnlyHTTPS"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.source.arn,
+      "${aws_s3_bucket.source.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+  }
+
+  statement {
+    sid    = "AllowBillingReadWriteAccess"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketPolicy",
+      "s3:PutObject",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+    resources = [
+      aws_s3_bucket.source.arn,
+      "${aws_s3_bucket.source.arn}/*",
+    ]
+    condition {
+      test     = "StringLike"
+      values   = ["arn:${local.partition}:cur:*:${local.account_id}:definition/*"]
+      variable = "aws:SourceArn"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [local.account_id]
+      variable = "aws:SourceAccount"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "replication" {
+  policy_id = "CrossRegionReplicationPolicy"
+
+  statement {
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+    resources = [aws_s3_bucket.source.arn]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+    ]
+    resources = ["${aws_s3_bucket.source.arn}/*"]
+  }
+
+  statement {
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+    resources = ["${var.destination_bucket_arn}/cur/${local.account_id}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "s3_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "batchoperations.s3.amazonaws.com",
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}

--- a/s3-cur-source/iam.tf
+++ b/s3-cur-source/iam.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_role" "replication" {
+  assume_role_policy    = data.aws_iam_policy_document.s3_assume_role.json
+  force_detach_policies = true
+  name_prefix           = "${var.resource_prefix}-replication"
+  path                  = "/"
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.resource_prefix}-replication"
+    }
+  )
+}
+
+resource "aws_iam_policy" "replication" {
+  name_prefix = "${var.resource_prefix}-replication"
+  policy      = data.aws_iam_policy_document.replication.json
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.resource_prefix}-replication"
+    }
+  )
+}
+
+resource "aws_iam_policy_attachment" "replication" {
+  name       = "${var.resource_prefix}-replication"
+  policy_arn = aws_iam_policy.replication.arn
+  roles      = [aws_iam_role.replication.name]
+}

--- a/s3-cur-source/locals.tf
+++ b/s3-cur-source/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  account_id  = data.aws_caller_identity.current.account_id
+  aws_region  = data.aws_region.current.name
+  bucket_name = "${var.resource_prefix}-${data.aws_caller_identity.current.account_id}-local"
+  partition   = data.aws_partition.current.partition
+  tags = merge(
+    var.tags,
+    {
+      Name = local.bucket_name
+    }
+  )
+}

--- a/s3-cur-source/outputs.tf
+++ b/s3-cur-source/outputs.tf
@@ -1,0 +1,24 @@
+output "cur_bucket_arn" {
+  description = "ARN of the S3 Bucket where the Cost and Usage Report is delivered"
+  value       = aws_s3_bucket.source.arn
+}
+
+output "cur_bucket_name" {
+  description = "Name of the S3 Bucket where the Cost and Usage Report is delivered"
+  value       = aws_s3_bucket.source.bucket
+}
+
+output "cur_report_arn" {
+  description = "ARN of the Cost and Usage Report"
+  value       = aws_cur_report_definition.source.arn
+}
+
+output "replication_role_arn" {
+  description = "ARN of the IAM role created for S3 replication"
+  value       = aws_iam_role.replication.arn
+}
+
+output "replication_role_name" {
+  description = "ARN of the IAM role created for S3 replication"
+  value       = aws_iam_role.replication.name
+}

--- a/s3-cur-source/s3.tf
+++ b/s3-cur-source/s3.tf
@@ -1,0 +1,91 @@
+resource "aws_s3_bucket" "source" {
+  bucket        = local.bucket_name
+  force_destroy = var.enable_force_destroy
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "source" {
+  bucket = aws_s3_bucket.source.bucket
+  rule {
+    id     = "ExpireObjects&NonCurrentVersions"
+    status = "Enabled"
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_version_expiration
+    }
+    expiration {
+      days                         = var.object_expiration_days
+      expired_object_delete_marker = true
+    }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "source" {
+  count = var.s3_access_logging.enabled ? 1 : 0
+
+  bucket        = aws_s3_bucket.source.bucket
+  target_bucket = var.s3_access_logging.bucket
+  target_prefix = var.s3_access_logging.prefix
+}
+
+resource "aws_s3_bucket_ownership_controls" "source" {
+  bucket = aws_s3_bucket.source.bucket
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_policy" "source" {
+  bucket = aws_s3_bucket.source.id
+  policy = data.aws_iam_policy_document.bucket_policy.json
+}
+
+resource "aws_s3_bucket_public_access_block" "source" {
+  bucket                  = aws_s3_bucket.source.bucket
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_replication_configuration" "replication" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
+  role   = aws_iam_role.replication.arn
+  bucket = aws_s3_bucket.source.id
+
+  rule {
+    id     = "ReplicationRule1"
+    status = "Enabled"
+    filter {
+      prefix = "cur/${local.account_id}"
+    }
+    delete_marker_replication {
+      status = "Enabled"
+    }
+    destination {
+      bucket        = var.destination_bucket_arn
+      storage_class = "STANDARD"
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "source" {
+  bucket = aws_s3_bucket.source.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+

--- a/s3-cur-source/variables.tf
+++ b/s3-cur-source/variables.tf
@@ -1,0 +1,61 @@
+variable "cur_name_suffix" {
+  default     = "cur"
+  description = "Suffix used to name the CUR report."
+  type        = string
+}
+
+variable "destination_bucket_arn" {
+  type        = string
+  description = "ARN of bucket where objects will be replicated."
+}
+
+variable "enable_force_destroy" {
+  default     = true
+  description = <<-EOF
+    Indicates all objects (including any locked objects) should be deleted from the
+    bucket when the bucket is destroyed.
+  EOF
+  type        = bool
+}
+
+variable "enable_split_cost_allocation_data" {
+  default     = false
+  description = "Enable split cost allocation data for ECS and EKS for this CUR report."
+  type        = bool
+}
+
+variable "noncurrent_version_expiration" {
+  default     = 32
+  description = "The number of days a noncurrent object is stored before it is expired."
+  type        = number
+}
+
+variable "object_expiration_days" {
+  default     = 64
+  description = "The number of days an object is stored before it is expired."
+  type        = number
+}
+
+variable "resource_prefix" {
+  description = "Prefix used for all named resources, including the S3 Bucket."
+  type        = string
+}
+
+variable "s3_access_logging" {
+  type = object({
+    enabled = bool
+    bucket  = string
+    prefix  = string
+  })
+  description = "S3 Access Logging configuration for the CUR bucket"
+  default = {
+    enabled = false
+    bucket  = null
+    prefix  = null
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to module resources."
+}

--- a/s3-cur-source/versions.tf
+++ b/s3-cur-source/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+      configuration_aliases = [
+        aws.us_east_1,
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Carries out the following:
- Organises Terraform code into proper file structure [data.tf, locals.tf, <resource>.tf, outputs.tf, variables.tf, versions.tf]
- Makes force_destroy a variable
- Update resource tagging, add it all relevant resources
- Make `aws_s3_bucket_lifecycle_configuration` configurable with variables for the default values
- Enhance bucket policy by concatenating the Billing statements
- Use IAM policy and attachment instead of inline policy for `aws_iam_role`
- Separate iam from s3 resources